### PR TITLE
make DRY create and delete spreadsheet config json file

### DIFF
--- a/app/models/concerns/config_json_file_creatable.rb
+++ b/app/models/concerns/config_json_file_creatable.rb
@@ -1,0 +1,23 @@
+module ConfigJsonFileCreatable
+  extend ActiveSupport::Concern
+
+  CONFIG_FILE_NAME = ENV['CONFIG_FILE_NAME']
+
+  def create_config_file
+    file = File.open(CONFIG_FILE_NAME,"w")
+    config_hash = {
+      client_id: ENV['CLIENT_ID'],
+      client_secret: ENV['CLIENT_SECRET'],
+      scope: [
+        ENV['SCOPE_ONE'],
+        ENV['SCOPE_TWO']
+      ],
+      refresh_token: ENV['REFRESH_TOKEN']
+    }
+
+    file.write(config_hash.to_json)
+    file.close
+
+    CONFIG_FILE_NAME
+  end
+end

--- a/app/models/concerns/config_json_file_deletable.rb
+++ b/app/models/concerns/config_json_file_deletable.rb
@@ -1,0 +1,9 @@
+module ConfigJsonFileDeletable
+  extend ActiveSupport::Concern
+
+  CONFIG_FILE_NAME = ENV['CONFIG_FILE_NAME']
+
+  def delete_config_file
+    File.delete(CONFIG_FILE_NAME) if File.exist?(CONFIG_FILE_NAME)
+  end
+end

--- a/app/services/copy_template_sheet.rb
+++ b/app/services/copy_template_sheet.rb
@@ -1,4 +1,7 @@
 class CopyTemplateSheet
+  include ConfigJsonFileCreatable
+  include ConfigJsonFileDeletable
+
   TEMPLATE_SHEET_TITLE = ENV['TEMPLATE_SHEET_TITLE']
 
   # とりあえずコンソールから手動で叩く想定で作成
@@ -7,32 +10,6 @@ class CopyTemplateSheet
     session = GoogleDrive::Session.from_config(create_config_file)
     template_sheet = session.spreadsheet_by_title(TEMPLATE_SHEET_TITLE)
     copied_sheet = template_sheet.copy("#{year}年#{month}月集計分")
-    delete_config_file
-  end
-
-  private
-  # todo
-  # 以下2つのメソッドはDRYじゃない(UpdateSpreadSheetにもある)
-  # Utilから呼び出せるようにする
-  def create_config_file
-    file = File.open(UpdateSpreadSheet::CONFIG_FILE_NAME,"w")
-    config_hash = {
-      client_id: ENV['CLIENT_ID'],
-      client_secret: ENV['CLIENT_SECRET'],
-      scope: [
-        ENV['SCOPE_ONE'],
-        ENV['SCOPE_TWO']
-      ],
-      refresh_token: ENV['REFRESH_TOKEN']
-    }
-
-    file.write(config_hash.to_json)
-    file.close
-
-    UpdateSpreadSheet::CONFIG_FILE_NAME
-  end
-
-  def delete_config_file
-    File.delete(CONFIG_FILE_NAME) if File.exist?(CONFIG_FILE_NAME)
+    delete_config_file if copied_sheet.present?
   end
 end

--- a/app/services/update_spread_sheet.rb
+++ b/app/services/update_spread_sheet.rb
@@ -2,6 +2,8 @@ class UpdateSpreadSheet
   require "google_drive"
 
   include BaseService
+  include ConfigJsonFileCreatable
+  include ConfigJsonFileDeletable
 
   CONFIG_FILE_NAME = ENV['CONFIG_FILE_NAME']
   WRS_NAME = ENV['WORK_REPORT_SHEET_NAME']
@@ -91,28 +93,6 @@ class UpdateSpreadSheet
 
   private
   attr_reader :session, :work_report_sheet, :work_report, :fixed_salary
-
-  def create_config_file
-    file = File.open(CONFIG_FILE_NAME,"w")
-    config_hash = {
-      client_id: ENV['CLIENT_ID'],
-      client_secret: ENV['CLIENT_SECRET'],
-      scope: [
-        ENV['SCOPE_ONE'],
-        ENV['SCOPE_TWO']
-      ],
-      refresh_token: ENV['REFRESH_TOKEN']
-    }
-
-    file.write(config_hash.to_json)
-    file.close
-
-    CONFIG_FILE_NAME
-  end
-
-  def delete_config_file
-    File.delete(CONFIG_FILE_NAME) if File.exist?(CONFIG_FILE_NAME)
-  end
 
   def update_sheet_to_ok! row_num
     work_report_sheet[row_num,STATUS_COL_NUM] = OK


### PR DESCRIPTION
スプレッドシートのconfigファイルの作成処理がDRYじゃなかったため、モジュールにして共通化した。

createとdeleteで別々のモジュールにしたが、分ける必要ないのではとも思う